### PR TITLE
reset version so release-plan will work on itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+# My awesome Changelog

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "release-plan",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "",
   "type": "module",
   "bin": "./dist/cli.js",


### PR DESCRIPTION
If you don't have a changelog things crash, and if your version in your package.json is higher than your last tag nothing happens