### PR TITLE
add --single-package option

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,10 +13,14 @@ yargs(process.argv.slice(2))
   .command(
     'prepare',
     `Edits the package.json and changelog files to prepare for release.`,
-    yargs => fromStdin(yargs),
+    yargs => fromStdin(yargs).option('singlePackage', {
+      type: 'string',
+      description:
+        'Allows you to run this command in a non monorepo and define the package name',
+    }),
     async function (opts) {
       let { prepare } = await import('./prepare.js');
-      let solution = await prepare(await newChangelogContent(opts));
+      let solution = await prepare(await newChangelogContent(opts), opts.singlePackage);
       let { explain } = await import('./plan.js');
       process.stdout.write(explain(solution));
       process.stdout.write(`\nSuccessfully prepared released\n`);
@@ -74,10 +78,15 @@ yargs(process.argv.slice(2))
   .command(
     'explain-plan',
     `Explains which packages need to be released at what versions and why.`,
-    yargs => fromStdin(yargs),
+    yargs => fromStdin(yargs)
+    .option('singlePackage', {
+      type: 'string',
+      description:
+        'Allows you to run this command in a non monorepo and define the package name',
+    }),
     async function (opts) {
       let { planVersionBumps, explain } = await import('./plan.js');
-      let solution = planVersionBumps(parseChangeLogOrExit(await newChangelogContent(opts)));
+      let solution = planVersionBumps(parseChangeLogOrExit(await newChangelogContent(opts)), opts.singlePackage);
       console.log(explain(solution));
     }
   )

--- a/src/plan.ts
+++ b/src/plan.ts
@@ -191,7 +191,7 @@ export function explain(solution: Solution) {
   return output.join('\n');
 }
 
-export function planVersionBumps(changed: ParsedChangelog): Solution {
+export function planVersionBumps(changed: ParsedChangelog, singlePackage?: string): Solution {
   let plan = new Plan();
   for (let section of changed.sections) {
     if ('unlabeled' in section) {
@@ -203,9 +203,14 @@ export function planVersionBumps(changed: ParsedChangelog): Solution {
       process.exit(-1);
     }
 
-    for (let pkg of section.packages) {
-      plan.addConstraint(`@embroider/${pkg}`, section.impact, `Appears in changelog section ${section.heading}`);
+    if (singlePackage) {
+      plan.addConstraint(singlePackage, section.impact, `Appears in changelog section ${section.heading}`);
+    } else {
+      for (let pkg of section.packages) {
+        plan.addConstraint(`@embroider/${pkg}`, section.impact, `Appears in changelog section ${section.heading}`);
+      }
     }
+
   }
 
   return plan.solve();

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -44,9 +44,9 @@ function updateVersions(solution: Solution) {
   }
 }
 
-export async function prepare(newChangelogContent: string) {
+export async function prepare(newChangelogContent: string, singlePackage?: string) {
   let changes = parseChangeLogOrExit(newChangelogContent);
-  let solution = planVersionBumps(changes);
+  let solution = planVersionBumps(changes, singlePackage);
   updateVersions(solution);
   let description = updateChangelog(newChangelogContent, solution);
   saveSolution(solution, description);


### PR DESCRIPTION
release-plan was originally designed to only work in monorepos, which makes a lot of sense because that's where it really shines!

There is however some value in running it in repos that only have one package in it because of the way that the deployment workflow happens so this PR adds a mode where you pass `--single-package=something` to bypass the code that figures out all the packages

This could probably be removed in future, I was just looking for the fastest way to implement this feature so it unblocked me 👍 