### PR TITLE
use dist/cli.js directly in workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           version: 8
       - name: npm publish
-        run: pnpm release-plan publish
+        run: node ./dist/cli.js publish
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-plan-preview.yml
+++ b/.github/workflows/release-plan-preview.yml
@@ -28,7 +28,7 @@ jobs:
         id: explanation
         run: |
           set -x
-          pnpm release-plan prepare --single-package=release-plan
+          node ./dist/cli.js prepare --single-package=release-plan
           jq .description .release-plan.json >> $GITHUB_OUTPUT
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I don't know why it's not actually registering the binary 🤔 