### PR TITLE
don't throw when we encounter an unknown package

### DIFF
--- a/src/plan.ts
+++ b/src/plan.ts
@@ -39,9 +39,8 @@ class Plan {
   addConstraint(packageName: string, impact: Impact, reason: string): void {
     let pkgConstraints = this.#constraints.get(packageName);
     if (!pkgConstraints) {
-      let err = new Error(`unknown package "${packageName}"`);
-      (err as any).unknownPackage = true;
-      throw err;
+      console.warn(chalk.yellow(`Warning: unknown package "${packageName}"`));
+      return;
     }
     if (!pkgConstraints.some(existing => existing.impact === impact && existing.reason === reason)) {
       pkgConstraints.push({ impact, reason });


### PR DESCRIPTION
If lerna-changelog reports a package that has changed that is set to `private: true` release-plan would throw because it didn't find that package in its plan.

This PR fixes that 👍 