### PR TITLE
use require.resolve to find lerna-changelog

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import yargs from 'yargs/yargs';
 import type { Argv } from 'yargs';
 

--- a/src/gather-changes.ts
+++ b/src/gather-changes.ts
@@ -1,6 +1,12 @@
 import execa from 'execa';
+import {resolve} from 'path';
+import { dirname } from 'path';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
 
 export async function gatherChanges() {
-  let result = await execa('pnpm', ['lerna-changelog', '--next-version', 'Release']);
+  const lernaChangelogPath = require.resolve('@ef4/lerna-changelog');
+  
+  let result = await execa('node', [resolve(dirname(lernaChangelogPath), 'bin', 'cli.js'), '--next-version', 'Release']);
   return result.stdout;
 }


### PR DESCRIPTION
This fixes a problem when you are trying to run release-plan in a consuming repo, it wouldn't be able to find the version of lerna-changelog that we need. This PR fixes that 🎉 