### PR TITLE
add --publish-branch if passed to release-plan publish

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,6 +49,11 @@ yargs(process.argv.slice(2))
           type: 'boolean',
           description:
             'Run through the release, but log to stdout instead of tagging/pushing/publishing',
+        })
+        .option('publish-branch', {
+          type: 'string',
+          description:
+            '(pnpm) optionally pass on the --publish-branch if you need to publish from a branch other than main|master',
         }),
     async function (opts) {
       await publish(opts);

--- a/src/publish.test.ts
+++ b/src/publish.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { npmPublish, IssueReporter } from './publish.js';
+import { Solution } from './plan.js';
+
+// we aren't currently using this so we can just ignore for now
+const reporter = new IssueReporter();
+
+describe('publish', function () {
+  describe('npmPublish', function () {
+    it('adds the correct args with no options', async function () {
+      const thingy = await npmPublish(
+        new Map([['thingy', { oldVersion: '3' }]]) as Solution,
+        reporter,
+        {},
+        'face',
+      );
+
+      expect(thingy).toMatchInlineSnapshot(`
+        {
+          "args": [
+            "publish",
+            "--access=public",
+          ],
+          "released": Map {},
+        }
+      `);
+    });
+
+    it('adds otp if passed by options', async function () {
+      const thingy = await npmPublish(
+        new Map([['thingy', { oldVersion: '3' }]]) as Solution,
+        reporter,
+        {
+          otp: '12345',
+        },
+        'face',
+      );
+
+      expect(thingy).toMatchInlineSnapshot(`
+        {
+          "args": [
+            "publish",
+            "--access=public",
+            "--otp=12345",
+          ],
+          "released": Map {},
+        }
+      `);
+    });
+
+    it('adds publish-branch if passed by options', async function () {
+      const thingy = await npmPublish(
+        new Map([['thingy', { oldVersion: '3' }]]) as Solution,
+        reporter,
+        {
+          publishBranch: 'best-branch',
+        },
+        'face',
+      );
+
+      expect(thingy).toMatchInlineSnapshot(`
+        {
+          "args": [
+            "publish",
+            "--access=public",
+            "--publish-branch=best-branch",
+          ],
+          "released": Map {},
+        }
+      `);
+    });
+  });
+});

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -10,6 +10,13 @@ import fsExtra from 'fs-extra';
 
 const { existsSync } = fsExtra;
 
+type PublishOptions = {
+  skipRepoSafetyCheck?: boolean;
+  dryRun?: boolean;
+  otp?: string;
+  publishBranch?: string;
+};
+
 async function hasCleanRepo(): Promise<boolean> {
   const result = await execa('git', ['status', '--porcelain=v1']);
   return result.stdout.length === 0;
@@ -27,7 +34,7 @@ function success(message: string) {
   process.stdout.write(`\n 🎉 ${message} 🎉\n`);
 }
 
-class IssueReporter {
+export class IssueReporter {
   hadIssues = false;
   reportFailure(message: string): void {
     this.hadIssues = true;
@@ -211,12 +218,29 @@ async function doesVersionExist(
   }
 }
 
-async function npmPublish(
+/**
+ * Call npm publish or pnpm publish on each of the packages in a plan
+ *
+ * @returns Promise<T> return value only used for testing
+ */
+export async function npmPublish(
   solution: Solution,
   reporter: IssueReporter,
   options: PublishOptions,
   packageManager: string,
-): Promise<void> {
+): Promise<{ args: string[]; released: Map<string, string> }> {
+  const args = ['publish', '--access=public'];
+
+  if (options.otp) {
+    args.push(`--otp=${options.otp}`);
+  }
+
+  if (options.publishBranch) {
+    args.push(`--publish-branch=${options.publishBranch}`);
+  }
+
+  const released = new Map();
+
   for (const [pkgName, entry] of solution) {
     if (!entry.impact) {
       continue;
@@ -230,7 +254,7 @@ async function npmPublish(
 
     if (preExisting) {
       info(`${pkgName} has already been publish @ version ${entry.newVersion}`);
-      return;
+      continue;
     }
 
     if (options.dryRun) {
@@ -239,20 +263,12 @@ async function npmPublish(
           options.otp ? ' --otp=*redacted*' : ''
         }\` for ${pkgName}, which would publish version ${entry.newVersion}`,
       );
+
+      released.set(pkgName, entry.newVersion);
       continue;
     }
 
     try {
-      const args = ['publish', '--access=public'];
-
-      if (options.otp) {
-        args.push(`--otp=${options.otp}`);
-      }
-
-      if (options.publishBranch) {
-        args.push(`--publish-branch=${options.publishBranch}`);
-      }
-
       await execa(packageManager, args, {
         cwd: dirname(entry.pkgJSONPath),
         stderr: 'inherit',
@@ -264,6 +280,11 @@ async function npmPublish(
       );
     }
   }
+
+  return {
+    args,
+    released,
+  };
 }
 
 function packageManager(): string {


### PR DESCRIPTION
This allows us to pass on the required [--publish-branch config](https://pnpm.io/cli/publish#--publish-branch-branch) whenever we're trying to release on a branch other than main or master 👍 

I added a test for the main function that changed too 🎉 