### PR TITLE
add ability to pass tag to publish command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -54,6 +54,10 @@ yargs(process.argv.slice(2))
           type: 'string',
           description:
             '(pnpm) optionally pass on the --publish-branch if you need to publish from a branch other than main|master',
+        })
+        .option('tag', {
+          type: 'string',
+          description: 'pass --tag to npm publish command',
         }),
     async function (opts) {
       await publish(opts);

--- a/src/publish.test.ts
+++ b/src/publish.test.ts
@@ -69,5 +69,27 @@ describe('publish', function () {
         }
       `);
     });
+
+    it('adds tag if passed by options', async function () {
+      const thingy = await npmPublish(
+        new Map([['thingy', { oldVersion: '3' }]]) as Solution,
+        reporter,
+        {
+          tag: 'best-tag',
+        },
+        'face',
+      );
+
+      expect(thingy).toMatchInlineSnapshot(`
+        {
+          "args": [
+            "publish",
+            "--access=public",
+            "--tag=best-tag",
+          ],
+          "released": Map {},
+        }
+      `);
+    });
   });
 });

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -15,6 +15,7 @@ type PublishOptions = {
   dryRun?: boolean;
   otp?: string;
   publishBranch?: string;
+  tag?: string;
 };
 
 async function hasCleanRepo(): Promise<boolean> {
@@ -237,6 +238,10 @@ export async function npmPublish(
 
   if (options.publishBranch) {
     args.push(`--publish-branch=${options.publishBranch}`);
+  }
+
+  if (options.tag) {
+    args.push(`--tag=${options.tag}`);
   }
 
   const released = new Map();


### PR DESCRIPTION
This is helpful if you're using release plan for a legacy branch and don't want it to be released as `latest`