### PR TITLE
fix import of semver

### DIFF
--- a/src/plan.ts
+++ b/src/plan.ts
@@ -1,11 +1,13 @@
 import type { Impact, ParsedChangelog } from './change-parser.js';
 import { publishedInterPackageDeps } from './interdep.js';
 import { assertNever } from 'assert-never';
-import { inc, satisfies } from 'semver';
+import semver from 'semver';
 import { highlightMarkdown } from './highlight.js';
 import chalk from 'chalk';
 import { resolve } from 'path';
 import fsExtra from 'fs-extra';
+
+const { inc, satisfies } = semver;
 
 const { existsSync, readJSONSync, writeJSONSync } = fsExtra;
 


### PR DESCRIPTION
I'm not exactly sure why this was working 🤔 semver hasn't been swapped over to a ESM module so it's not an upstream issue but I got an error complaining about this: 

https://github.com/emberjs/ember-optional-features/actions/runs/7904746758/job/21575788951#step:5:15

Edit: I've tested this locally and I'm happy enough with it to merge without waiting for a review 👍 