### PR TITLE
add the default github-changelog unlabelled section name to parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@ef4/lerna-changelog": "^2.1.0",
+    "@ef4/lerna-changelog": "^2.2.1",
     "@manypkg/get-packages": "^2.2.0",
     "@npmcli/package-json": "^5.0.0",
     "@octokit/rest": "^19.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@ef4/lerna-changelog':
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^2.2.1
+        version: 2.2.1
       '@manypkg/get-packages':
         specifier: ^2.2.0
         version: 2.2.0
@@ -104,8 +104,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /@ef4/lerna-changelog@2.1.0:
-    resolution: {integrity: sha512-c6301SsWdOBrTGEkQmDTK5dDJUX2+03kN6UYZhewkqih3vy3HZxp1G1eJPVPd5EQpaLRptxFsMtgDcsabPZmRg==}
+  /@ef4/lerna-changelog@2.2.1:
+    resolution: {integrity: sha512-x0SkFpfvNj6l4LV6UnvnWIohmt8bC+i/P3ybmPc8X92KVMP6X/rkPeOxa2hI8BfDEHJMNXLJrDgQrJawI57aGQ==}
     engines: {node: 12.* || 14.* || >= 16}
     hasBin: true
     dependencies:

--- a/src/change-parser.ts
+++ b/src/change-parser.ts
@@ -30,6 +30,9 @@ const knownSections: Record<string, { impact: Impact } | { unlabeled: true }> =
     ':question: Unlabeled': {
       unlabeled: true,
     },
+    ':present: Additional updates': {
+      unlabeled: true,
+    },
   };
 
 const ignoredSections = [/Committers: \d+/];


### PR DESCRIPTION
This will make sure that if you don't have any config release-plan notices to tag the "Aditional Changes" as "unlabelled"