### PR TITLE
Fix changelog parsing on ignored packages (when PRs are either labeled or unlabeled)

### DIFF
--- a/src/change-parser.parseChangelog.test.ts
+++ b/src/change-parser.parseChangelog.test.ts
@@ -14,7 +14,7 @@ describe('parseChangeLog', () => {
 * \`ember-repl\`
   * [#1687](https://github.com/NullVoxPopuli/limber/pull/1687) Allow passing rehype plugins to the markdown renderer in ember-repl ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
 `;
-    const result = parseChangeLog(changelog);
+    const result = parseChangeLog(changelog, new Set(['ember-repl']));
 
     expect(result).toMatchInlineSnapshot(`
       {
@@ -50,7 +50,7 @@ describe('parseChangeLog', () => {
 - [@NullVoxPopuli](https://github.com/NullVoxPopuli)
 - [@johanrd](https://github.com/johanrd)
 `;
-    const result = parseChangeLog(changelog);
+    const result = parseChangeLog(changelog, new Set(['ember-repl']));
 
     expect(result).toMatchInlineSnapshot(`
       {
@@ -69,7 +69,7 @@ describe('parseChangeLog', () => {
 
   it('does not blow up on empty changelog', () => {
     const changelog = '';
-    const result = parseChangeLog(changelog);
+    const result = parseChangeLog(changelog, new Set(['ember-repl']));
 
     expect(result).toMatchInlineSnapshot(`
     {
@@ -89,7 +89,7 @@ describe('parseChangeLog', () => {
 * Other
   * [#1667](https://github.com/NullVoxPopuli/limber/pull/1667) Update pnpm to v8.15.3 ([@renovate[bot]](https://github.com/apps/renovate))
 `;
-    const result = parseChangeLog(changelog);
+    const result = parseChangeLog(changelog, new Set(['ember-repl']));
 
     expect(result).toMatchInlineSnapshot(`
       {
@@ -109,7 +109,7 @@ describe('parseChangeLog', () => {
 * \`ember-repl\`, \`ember-repl-test-app\`
   * [#1687](https://github.com/NullVoxPopuli/limber/pull/1687) Allow passing rehype plugins to the markdown renderer in ember-repl ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
 `;
-    const result = parseChangeLog(changelog);
+    const result = parseChangeLog(changelog, new Set(['ember-repl']));
 
     expect(result).toMatchInlineSnapshot(`
       {

--- a/src/change-parser.parseChangelog.test.ts
+++ b/src/change-parser.parseChangelog.test.ts
@@ -78,8 +78,9 @@ describe('parseChangeLog', () => {
     `);
   });
 
-  it('ignores unlabeled PRs if they come from ignored packages', () => {
-    const changelog = `
+  describe('with ignored packages (the inverse of the passed allow-list)', () => {
+    it('ignores unlabeled PRs if they come from ignored packages', () => {
+      const changelog = `
 #### :present: Additional updates
 * \`tutorial\`
   * [#1618](https://github.com/NullVoxPopuli/limber/pull/1618) Add note about trying out Polaris ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
@@ -89,22 +90,17 @@ describe('parseChangeLog', () => {
 * Other
   * [#1667](https://github.com/NullVoxPopuli/limber/pull/1667) Update pnpm to v8.15.3 ([@renovate[bot]](https://github.com/apps/renovate))
 `;
-    const result = parseChangeLog(changelog, new Set(['ember-repl']));
+      const result = parseChangeLog(changelog, new Set(['ember-repl']));
 
-    expect(result).toMatchInlineSnapshot(`
-      {
-        "sections": [
-          {
-            "summaryText": "",
-            "unlabeled": true,
-          },
-        ],
-      }
-    `);
-  });
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "sections": [],
+        }
+      `);
+    });
 
-  it('does not ignore unlabeled PRs if they come from known packages', () => {
-    const changelog = `
+    it('does not ignore unlabeled PRs if they come from known packages', () => {
+      const changelog = `
 #### :present: Additional updates
 * \`tutorial\`
   * [#1618](https://github.com/NullVoxPopuli/limber/pull/1618) Add note about trying out Polaris ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
@@ -114,24 +110,51 @@ describe('parseChangeLog', () => {
 * Other
   * [#1667](https://github.com/NullVoxPopuli/limber/pull/1667) Update pnpm to v8.15.3 ([@renovate[bot]](https://github.com/apps/renovate))
 `;
-    const result = parseChangeLog(changelog, new Set(['tutorial']));
+      const result = parseChangeLog(changelog, new Set(['tutorial']));
 
-    expect(result).toMatchInlineSnapshot(`
-      {
-        "sections": [
-          {
-            "summaryText": "* \`tutorial\`
-        * [#1618](https://github.com/NullVoxPopuli/limber/pull/1618) Add note about trying out Polaris ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
-        * [#1680](https://github.com/NullVoxPopuli/limber/pull/1680) feat: Arg Components ([@MichalBryxi](https://github.com/MichalBryxi))",
-            "unlabeled": true,
-          },
-        ],
-      }
-    `);
-  });
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "sections": [
+            {
+              "summaryText": "* \`tutorial\`
+          * [#1618](https://github.com/NullVoxPopuli/limber/pull/1618) Add note about trying out Polaris ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
+          * [#1680](https://github.com/NullVoxPopuli/limber/pull/1680) feat: Arg Components ([@MichalBryxi](https://github.com/MichalBryxi))",
+              "unlabeled": true,
+            },
+          ],
+        }
+      `);
+    });
 
-  it('ignores packages on labeled PRs if those packages are ignored', () => {
-    const changelog = `## Release (2024-03-10)
+    it('does not ignore unlabeled PRs if they come from known packages', () => {
+      const changelog = `
+#### :present: Additional updates
+* \`tutorial\`
+  * [#1618](https://github.com/NullVoxPopuli/limber/pull/1618) Add note about trying out Polaris ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
+  * [#1680](https://github.com/NullVoxPopuli/limber/pull/1680) feat: Arg Components ([@MichalBryxi](https://github.com/MichalBryxi))
+* \`limber\`
+  * [#1642](https://github.com/NullVoxPopuli/limber/pull/1642) Fix for #1641: Alternative 1) Remove \`z-10\` from resize-handle ([@johanrd](https://github.com/johanrd))
+* Other
+  * [#1667](https://github.com/NullVoxPopuli/limber/pull/1667) Update pnpm to v8.15.3 ([@renovate[bot]](https://github.com/apps/renovate))
+`;
+      const result = parseChangeLog(changelog, new Set(['tutorial']));
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "sections": [
+            {
+              "summaryText": "* \`tutorial\`
+          * [#1618](https://github.com/NullVoxPopuli/limber/pull/1618) Add note about trying out Polaris ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
+          * [#1680](https://github.com/NullVoxPopuli/limber/pull/1680) feat: Arg Components ([@MichalBryxi](https://github.com/MichalBryxi))",
+              "unlabeled": true,
+            },
+          ],
+        }
+      `);
+    });
+
+    it('ignores packages on labeled PRs if those packages are ignored', () => {
+      const changelog = `## Release (2024-03-10)
 
 #### :boom: Breaking Change
 * \`ember-repl\`, \`ember-repl-test-app\`
@@ -141,27 +164,58 @@ describe('parseChangeLog', () => {
 * \`ember-repl\`, \`ember-repl-test-app\`
   * [#1687](https://github.com/NullVoxPopuli/limber/pull/1687) Allow passing rehype plugins to the markdown renderer in ember-repl ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
 `;
-    const result = parseChangeLog(changelog, new Set(['ember-repl']));
+      const result = parseChangeLog(changelog, new Set(['ember-repl']));
 
-    expect(result).toMatchInlineSnapshot(`
-      {
-        "sections": [
-          {
-            "heading": ":boom: Breaking Change",
-            "impact": "major",
-            "packages": [
-              "ember-repl",
-            ],
-          },
-          {
-            "heading": ":rocket: Enhancement",
-            "impact": "minor",
-            "packages": [
-              "ember-repl",
-            ],
-          },
-        ],
-      }
-    `);
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "sections": [
+            {
+              "heading": ":boom: Breaking Change",
+              "impact": "major",
+              "packages": [
+                "ember-repl",
+              ],
+            },
+            {
+              "heading": ":rocket: Enhancement",
+              "impact": "minor",
+              "packages": [
+                "ember-repl",
+              ],
+            },
+          ],
+        }
+      `);
+    });
+
+    it('if all unlabeled changes are from ignored packages, we do not care about any of those changes being unlabeled', () => {
+      const changelog = `## Release (2024-03-10)
+
+#### :boom: Breaking Change
+* \`ember-repl\`
+  * [#1674](https://github.com/NullVoxPopuli/limber/pull/1674) Refactor the compilation library to prepare for broader usage ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
+
+#### :present: Additional updates
+* \`tutorial\`
+  * [#1618](https://github.com/NullVoxPopuli/limber/pull/1618) Add note about trying out Polaris ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
+  * [#1680](https://github.com/NullVoxPopuli/limber/pull/1680) feat: Arg Components ([@MichalBryxi](https://github.com/MichalBryxi))
+
+  `;
+      const result = parseChangeLog(changelog, new Set(['ember-repl']));
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "sections": [
+            {
+              "heading": ":boom: Breaking Change",
+              "impact": "major",
+              "packages": [
+                "ember-repl",
+              ],
+            },
+          ],
+        }
+      `);
+    });
   });
 });

--- a/src/change-parser.parseChangelog.test.ts
+++ b/src/change-parser.parseChangelog.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+
+import { parseChangeLog } from './change-parser.js';
+
+describe('parseChangeLog', () => {
+  it('groups changes by sections', () => {
+    const changelog = `## Release (2024-03-10)
+
+#### :boom: Breaking Change
+* \`ember-repl\`
+  * [#1674](https://github.com/NullVoxPopuli/limber/pull/1674) Refactor the compilation library to prepare for broader usage ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
+
+#### :rocket: Enhancement
+* \`ember-repl\`
+  * [#1687](https://github.com/NullVoxPopuli/limber/pull/1687) Allow passing rehype plugins to the markdown renderer in ember-repl ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
+`;
+    const result = parseChangeLog(changelog);
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "sections": [
+          {
+            "heading": ":boom: Breaking Change",
+            "impact": "major",
+            "packages": [
+              "ember-repl",
+            ],
+          },
+          {
+            "heading": ":rocket: Enhancement",
+            "impact": "minor",
+            "packages": [
+              "ember-repl",
+            ],
+          },
+        ],
+      }
+    `);
+  });
+
+  it('ignores committers', () => {
+    const changelog = `## Release (2024-03-10)
+
+#### :boom: Breaking Change
+* \`ember-repl\`
+  * [#1674](https://github.com/NullVoxPopuli/limber/pull/1674) Refactor the compilation library to prepare for broader usage ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
+
+#### Committers: 3
+- Michal Bryxí ([@MichalBryxi](https://github.com/MichalBryxi))
+- [@NullVoxPopuli](https://github.com/NullVoxPopuli)
+- [@johanrd](https://github.com/johanrd)
+`;
+    const result = parseChangeLog(changelog);
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "sections": [
+          {
+            "heading": ":boom: Breaking Change",
+            "impact": "major",
+            "packages": [
+              "ember-repl",
+            ],
+          },
+        ],
+      }
+    `);
+  });
+
+  it('does not blow up on empty changelog', () => {
+    const changelog = '';
+    const result = parseChangeLog(changelog);
+
+    expect(result).toMatchInlineSnapshot(`
+    {
+        "sections": [],
+      }
+    `);
+  });
+
+  it('ignores unlabeled PRs if they come from ignored packages', () => {
+    const changelog = `
+#### :present: Additional updates
+* \`tutorial\`
+  * [#1618](https://github.com/NullVoxPopuli/limber/pull/1618) Add note about trying out Polaris ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
+  * [#1680](https://github.com/NullVoxPopuli/limber/pull/1680) feat: Arg Components ([@MichalBryxi](https://github.com/MichalBryxi))
+* \`limber\`
+  * [#1642](https://github.com/NullVoxPopuli/limber/pull/1642) Fix for #1641: Alternative 1) Remove \`z-10\` from resize-handle ([@johanrd](https://github.com/johanrd))
+* Other
+  * [#1667](https://github.com/NullVoxPopuli/limber/pull/1667) Update pnpm to v8.15.3 ([@renovate[bot]](https://github.com/apps/renovate))
+`;
+    const result = parseChangeLog(changelog);
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "sections": [],
+      }
+    `);
+  });
+
+  it('ignores packages on labeled PRs if those packages are ignored', () => {
+    const changelog = `## Release (2024-03-10)
+
+#### :boom: Breaking Change
+* \`ember-repl\`, \`ember-repl-test-app\`
+  * [#1674](https://github.com/NullVoxPopuli/limber/pull/1674) Refactor the compilation library to prepare for broader usage ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
+
+#### :rocket: Enhancement
+* \`ember-repl\`, \`ember-repl-test-app\`
+  * [#1687](https://github.com/NullVoxPopuli/limber/pull/1687) Allow passing rehype plugins to the markdown renderer in ember-repl ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
+`;
+    const result = parseChangeLog(changelog);
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "sections": [
+          {
+            "heading": ":boom: Breaking Change",
+            "impact": "major",
+            "packages": [
+              "ember-repl",
+            ],
+          },
+          {
+            "heading": ":rocket: Enhancement",
+            "impact": "minor",
+            "packages": [
+              "ember-repl",
+            ],
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/src/change-parser.parseChangelog.test.ts
+++ b/src/change-parser.parseChangelog.test.ts
@@ -93,7 +93,39 @@ describe('parseChangeLog', () => {
 
     expect(result).toMatchInlineSnapshot(`
       {
-        "sections": [],
+        "sections": [
+          {
+            "summaryText": "",
+            "unlabeled": true,
+          },
+        ],
+      }
+    `);
+  });
+
+  it('does not ignore unlabeled PRs if they come from known packages', () => {
+    const changelog = `
+#### :present: Additional updates
+* \`tutorial\`
+  * [#1618](https://github.com/NullVoxPopuli/limber/pull/1618) Add note about trying out Polaris ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
+  * [#1680](https://github.com/NullVoxPopuli/limber/pull/1680) feat: Arg Components ([@MichalBryxi](https://github.com/MichalBryxi))
+* \`limber\`
+  * [#1642](https://github.com/NullVoxPopuli/limber/pull/1642) Fix for #1641: Alternative 1) Remove \`z-10\` from resize-handle ([@johanrd](https://github.com/johanrd))
+* Other
+  * [#1667](https://github.com/NullVoxPopuli/limber/pull/1667) Update pnpm to v8.15.3 ([@renovate[bot]](https://github.com/apps/renovate))
+`;
+    const result = parseChangeLog(changelog, new Set(['tutorial']));
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "sections": [
+          {
+            "summaryText": "* \`tutorial\`
+        * [#1618](https://github.com/NullVoxPopuli/limber/pull/1618) Add note about trying out Polaris ([@NullVoxPopuli](https://github.com/NullVoxPopuli))
+        * [#1680](https://github.com/NullVoxPopuli/limber/pull/1680) feat: Arg Components ([@MichalBryxi](https://github.com/MichalBryxi))",
+            "unlabeled": true,
+          },
+        ],
       }
     `);
   });

--- a/src/change-parser.ts
+++ b/src/change-parser.ts
@@ -75,11 +75,15 @@ function parseSection(
   }
 
   if ('unlabeled' in sectionConfig) {
-    const relevantLines = filteredUnlabeled([...lines], publishableNames);
+    const relevantLines = filteredUnlabeled(lines, publishableNames);
 
-    const consumed = consumeSection(relevantLines);
+    if (relevantLines.length) {
+      const consumed = consumeSection(relevantLines);
 
-    return { unlabeled: true, summaryText: consumed.join('\n') };
+      return { unlabeled: true, summaryText: consumed.join('\n') };
+    } else {
+      return;
+    }
   }
 
   const packages = new Set<string>();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -107,8 +107,12 @@ yargs(process.argv.slice(2))
       }),
     async function (opts) {
       const { planVersionBumps, explain } = await import('./plan.js');
+      const { getPackages } = await import('./interdep.js');
+      const packages = getPackages('./');
+      const publishableNames = new Set(packages.keys());
+
       const solution = planVersionBumps(
-        parseChangeLogOrExit(await newChangelogContent(opts)),
+        parseChangeLogOrExit(await newChangelogContent(opts), publishableNames),
         opts.singlePackage,
       );
       console.log(explain(solution));

--- a/src/interdep.ts
+++ b/src/interdep.ts
@@ -13,6 +13,13 @@ export interface PkgEntry {
   pkg: any;
 }
 
+export function getPublishablePackageNames(rootDir: string): Set<string> {
+  const packages = getPackages(rootDir);
+  const publishableNames = new Set(packages.keys());
+
+  return publishableNames;
+}
+
 export function getPackages(rootDir: string): Map<string, PkgEntry> {
   const packages: Map<string, PkgEntry> = new Map();
 

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -3,6 +3,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import type { Solution } from './plan.js';
 import { planVersionBumps, saveSolution } from './plan.js';
 import fsExtra from 'fs-extra';
+import { getPublishablePackageNames } from './interdep.js';
 
 const { readJSONSync, writeJSONSync } = fsExtra;
 
@@ -69,7 +70,8 @@ export async function prepare(
   newChangelogContent: string,
   singlePackage?: string,
 ) {
-  const changes = parseChangeLogOrExit(newChangelogContent);
+  const publishableNames = getPublishablePackageNames('./');
+  const changes = parseChangeLogOrExit(newChangelogContent, publishableNames);
   const solution = planVersionBumps(changes, singlePackage);
   updateVersions(solution);
   const description = updateChangelog(newChangelogContent, solution);


### PR DESCRIPTION
Resolves: https://github.com/embroider-build/create-release-plan-setup/issues/91

Helps with: https://github.com/adopted-ember-addons/program-guidelines/issues/28

Unblocks: https://github.com/NullVoxPopuli/limber/pull/1673
As well as a few releases on the adopted ember addons org (I don't remember where now, but folks have arbitrarily been working around the problem by adding `internal` to their PRs -- so this is more a fix for a big annoyance than a fix for something show-stopping).

This seems to do what I want, _however_ it looks like like we need to do further changelog filtering and _not_ use `@ef4/lerna-changelog`'s default output.
- package list should exclude private packages
- package groups should be combined since if just removing the string, we'd have duplicate package groups.

Alternate fix here: https://github.com/embroider-build/github-changelog/pull/16 (which I think is he correct fix and we _should not_ merge this (#60) PR)

## Testing

In the root package.json:

```
"release-plan": "github:embroider-build/release-plan#dist/ignore-private-packages-detected-from-the-changelog-generator-dist"
```
or
```
"release-plan": "github:embroider-build/release-plan#bbd8d70"
```

Preview: https://github.com/NullVoxPopuli/limber/pull/1673
![image](https://github.com/embroider-build/release-plan/assets/199018/2f345f96-92fc-4893-a0b7-174f4368d622)
