### PR TITLE
Add support for specifying --access, aligning better with default publish behavior

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,6 +58,11 @@ yargs(process.argv.slice(2))
         .option('tag', {
           type: 'string',
           description: 'pass --tag to npm publish command',
+        })
+        .option('access', {
+          choices: ['public', 'restricted'],
+          description:
+            'Tells the registry whether the published package should be public or restricted.',
         }),
     async function (opts) {
       await publish(opts);

--- a/src/publish.test.ts
+++ b/src/publish.test.ts
@@ -19,7 +19,25 @@ describe('publish', function () {
         {
           "args": [
             "publish",
-            "--access=public",
+          ],
+          "released": Map {},
+        }
+      `);
+    });
+
+    it('adds access if passed by options', async function () {
+      const thingy = await npmPublish(
+        new Map([['thingy', { oldVersion: '3' }]]) as Solution,
+        reporter,
+        { access: 'restricted' },
+        'face',
+      );
+
+      expect(thingy).toMatchInlineSnapshot(`
+        {
+          "args": [
+            "publish",
+            "--access=restricted",
           ],
           "released": Map {},
         }
@@ -40,7 +58,6 @@ describe('publish', function () {
         {
           "args": [
             "publish",
-            "--access=public",
             "--otp=12345",
           ],
           "released": Map {},
@@ -62,7 +79,6 @@ describe('publish', function () {
         {
           "args": [
             "publish",
-            "--access=public",
             "--publish-branch=best-branch",
           ],
           "released": Map {},
@@ -84,7 +100,6 @@ describe('publish', function () {
         {
           "args": [
             "publish",
-            "--access=public",
             "--tag=best-tag",
           ],
           "released": Map {},
@@ -117,7 +132,6 @@ describe('publish', function () {
         {
           "args": [
             "publish",
-            "--access=public",
             "--tag=best-tag",
           ],
           "released": Map {},

--- a/src/publish.test.ts
+++ b/src/publish.test.ts
@@ -107,6 +107,27 @@ describe('publish', function () {
       `);
     });
 
+    it('adds dry-run if passed by options', async function () {
+      const thingy = await npmPublish(
+        new Map([['thingy', { oldVersion: '3' }]]) as Solution,
+        reporter,
+        {
+          dryRun: true,
+        },
+        'face',
+      );
+
+      expect(thingy).toMatchInlineSnapshot(`
+        {
+          "args": [
+            "publish",
+            "--dry-run",
+          ],
+          "released": Map {},
+        }
+      `);
+    });
+
     it('warns that a version exists if we are trying to release', async function () {
       const consoleSpy = vi.spyOn(process.stdout, 'write');
 

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -249,6 +249,10 @@ export async function npmPublish(
     args.push(`--access=${options.access}`);
   }
 
+  if (options.dryRun) {
+    args.push('--dry-run');
+  }
+
   const released = new Map();
 
   for (const [pkgName, entry] of solution) {
@@ -271,13 +275,11 @@ export async function npmPublish(
 
     if (options.dryRun) {
       info(
-        `--dryRun active. Skipping \`${packageManager} publish --access=public${
+        `--dryRun active. Adding \`--dry-run\` flag to \`${packageManager} publish${
           options.otp ? ' --otp=*redacted*' : ''
-        }\` for ${pkgName}, which would publish version ${entry.newVersion}`,
+        }\` for ${pkgName}, which would publish version ${entry.newVersion}\n`,
       );
-
       released.set(pkgName, entry.newVersion);
-      continue;
     }
 
     try {

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -16,6 +16,7 @@ type PublishOptions = {
   otp?: string;
   publishBranch?: string;
   tag?: string;
+  access?: string;
 };
 
 async function hasCleanRepo(): Promise<boolean> {
@@ -230,7 +231,7 @@ export async function npmPublish(
   options: PublishOptions,
   packageManager: string,
 ): Promise<{ args: string[]; released: Map<string, string> }> {
-  const args = ['publish', '--access=public'];
+  const args = ['publish'];
 
   if (options.otp) {
     args.push(`--otp=${options.otp}`);
@@ -242,6 +243,10 @@ export async function npmPublish(
 
   if (options.tag) {
     args.push(`--tag=${options.tag}`);
+  }
+
+  if (options.access) {
+    args.push(`--access=${options.access}`);
   }
 
   const released = new Map();


### PR DESCRIPTION
Closes #80 

Changes:

- Update the `--dry-run` flag so it is passed to `pnpm publish` to get more useful feedback.
- Remove the hardcoded `--access=public` argument and instead allow users to pass the `--access` flag with `public` or `restricted` set.  

Previously, running `pnpm release-plan publish` would force any package to publish as public, even if the access was set to restricted in the package.json.  

This change better matches the default behavior of `pnpm publish` and allows scoped packages to avoid being switched to public accidentally. 

With this change, the expected behaviors are:

1. Running publish without an `--access` flag will respect the [publishConfig](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#publishconfig) access set in `package.json`
2. Running publish with an `--access` flag will override the publishConfig access set in `package.json`
3. Running publish without an `--access` flag and no publishConfig access set in `package.json`
	1. if your package is scoped, it will publish with restricted access
		"By default, scoped packages are published with private visibility." [[source](https://docs.npmjs.com/creating-and-publishing-private-packages#publishing-private-packages)]
	1. otherwise, it will use the default publish 
		"By default npm will publish to the public registry. This can be overridden by specifying a different default registry or using a scope in the name, combined with a scope-configured registry (see package.json)." [[source](https://docs.npmjs.com/cli/v8/commands/npm-publish#description)]

> [!IMPORTANT]
> Item 3 here could use extra consideration because _I think_ it could cause a breaking change for folks who do not set the access in their package.json or publish command.
> 
--- 
