### PR TITLE
allow you to define a semver tag when using prerelease

### DIFF
--- a/src/plan.test.ts
+++ b/src/plan.test.ts
@@ -114,4 +114,45 @@ describe('plan', function () {
       ]),
     );
   });
+
+  it('allows you to define semver tag', async () => {
+    project.pkg['release-plan'] = {
+      semverIncrementAs: {
+        major: 'premajor',
+      },
+      semverIncrementTag: 'alpha',
+    };
+
+    await project.write();
+
+    const solution = planVersionBumps({
+      sections: [
+        {
+          packages: ['test-package'],
+          impact: 'major',
+          heading: 'breaking',
+        },
+      ],
+    });
+
+    expect(solution).to.deep.equal(
+      new Map([
+        [
+          'test-package',
+          {
+            constraints: [
+              {
+                impact: 'major',
+                reason: 'Appears in changelog section breaking',
+              },
+            ],
+            impact: 'major',
+            newVersion: '2.0.0-alpha.0',
+            oldVersion: '1.2.3',
+            pkgJSONPath: './package.json',
+          },
+        ],
+      ]),
+    );
+  });
 });

--- a/src/plan.ts
+++ b/src/plan.ts
@@ -65,6 +65,7 @@ class Plan {
         const newVersion = inc(
           entry.version,
           this.#configureImpact(pkgName, impact),
+          this.#semverTag(pkgName),
         )!;
         solution.set(pkgName, {
           impact,
@@ -87,6 +88,11 @@ class Plan {
       }
     }
     return impact;
+  }
+
+  #semverTag(pkgName: string): Impact {
+    const packageJson = this.#pkgs.get(pkgName)?.pkg;
+    return packageJson?.['release-plan']?.semverIncrementTag;
   }
 
   #expandWorkspaceRange(


### PR DESCRIPTION
This just allows you to have prereleases with versions like `2.0.0-alpha.0` rather than just `2.0.0-0`