### PR TITLE
support github enterprise api url via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,17 @@ For projects that need extra control over how versions are incremented `release-
 ```
 Will mean that any breaking change is treated as a minor which is useful in case the project is in the pre 1.0 stage. Please use responsibly
 
+## Usage in GitHub Enterprise
+to use release-plan in GitHub enterprise environment you have to set GITHUB_DOMAIN to your ghe domain
+
+GITHUB_DOMAIN=github.custom.com
+
+
+if you have a custom api endpoint you need to set it with
+GITHUB_API_URL to your ghe api url e.g.
+
+GITHUB_API_URL=https://api.github.custom.com
+
 ## Comparison
 
 Note that we take the stance of reducing friction for new contributors (regardless of how new to GitHub they are), we want to optimize for the contribution, and assume that maintainers can handle a little bit of process -- and with this stance, changesets is the _most work_ out of this comparison.

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -332,7 +332,17 @@ To publish a release you should start from a clean repo. Run "npx release-plan p
     process.exit(-1);
   }
 
-  const octokit = new Octokit({ auth: process.env.GITHUB_AUTH });
+  let baseUrl = undefined;
+  if (process.env.GITHUB_DOMAIN) {
+    baseUrl = `https://api.${process.env.GITHUB_DOMAIN}`;
+  }
+  if (process.env.GITHUB_API_URL) {
+    baseUrl = process.env.GITHUB_API_URL;
+  }
+  const octokit = new Octokit({
+    auth: process.env.GITHUB_AUTH,
+    baseUrl,
+  });
 
   const representativeTag = chooseRepresentativeTag(solution);
 


### PR DESCRIPTION
pass GITHUB_API_URL to Octokit baseUrl, if its undefined Octokit falls back to default value


same support in https://github.com/embroider-build/github-changelog/pull/33