### PR TITLE
feat: Display new package versions as list

### DIFF
--- a/src/prepare.test.ts
+++ b/src/prepare.test.ts
@@ -35,7 +35,7 @@ describe('prepare', function () {
 
 ## v1.0.0
 
-thing v1.0.0 (major)
+* thing v1.0.0 (major)
 
 - added release-plan (how did I live without it!?)
 - releasing initial working version
@@ -68,7 +68,7 @@ thing v1.0.0 (major)
 
 ## v1.0.0
 
-thing v1.0.0 (major)
+* thing v1.0.0 (major)
 
 - added release-plan (how did I live without it!?)
 - releasing initial working version

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -49,7 +49,7 @@ function versionSummary(solution: Solution): string {
   const result: string[] = [];
   for (const [pkgName, entry] of solution) {
     if (entry.impact) {
-      result.push(`${pkgName} ${entry.newVersion} (${entry.impact})`);
+      result.push(`* ${pkgName} ${entry.newVersion} (${entry.impact})`);
     }
   }
   return result.join('\n');


### PR DESCRIPTION
Since Markdown doesn't display single line breaks, either two line breaks can be used (althought this adds more padding above and below each line) or they can be treated as items of a list.