### PR TITLE
refactor: Create tags via GitHub REST API

### DIFF
--- a/src/publish.test.ts
+++ b/src/publish.test.ts
@@ -43,6 +43,8 @@ vi.mock('@octokit/rest', () => {
   };
 });
 
+vi.stubEnv('GITHUB_SHA', 'test-sha');
+
 describe('publish', function () {
   it('publish support custom base api url', function () {
     process.env.GITHUB_API_URL = 'https://api.custombase.com';
@@ -357,6 +359,7 @@ describe('publish', function () {
             "owner": "embroider-build",
             "repo": "release-plan",
             "tag_name": "v1.0.0-release-plan",
+            "target_commitish": "test-sha",
           },
         ]
       `);

--- a/src/publish.test.ts
+++ b/src/publish.test.ts
@@ -38,6 +38,13 @@ vi.mock('@octokit/rest', () => {
             throw err;
           },
         },
+        git: {
+          getRef() {
+            const err = new Error() as any;
+            err.status = 404;
+            throw err;
+          },
+        },
       };
     },
   };


### PR DESCRIPTION
Creating/pushing tags is the only place the `git` CLI is used (except for checking if the repository is "clean" in `hasCleanRepo`). Since the `git` command uses the provided `GITHUB_TOKEN` from GitHub Actions but a different token can be provided via `GITHUB_AUTH`, different users would be in charge of creating tags and creating releases.

The GitHub REST API can also [create a tag](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release) when creating a release via the `target_commitish` property:
> Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists. Default: the repository's default branch.

By creating the tags via Octokit with the REST API, we can guarantee that all remote actions are performed by the same user.