### PR TITLE
make sure the changelog only creates one version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cli-highlight": "^2.1.11",
     "execa": "^9.5.2",
     "fs-extra": "^11.2.0",
-    "github-changelog": "^2.0.0",
+    "github-changelog": "^2.1.1",
     "js-yaml": "^4.1.0",
     "latest-version": "^9.0.0",
     "parse-github-repo-url": "^1.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^11.2.0
         version: 11.2.0
       github-changelog:
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^2.1.1
+        version: 2.1.1
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
@@ -1501,8 +1501,8 @@ packages:
   get-tsconfig@4.10.1:
     resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
 
-  github-changelog@2.0.0:
-    resolution: {integrity: sha512-JdAwddNCvHkZY/pTMqpoaLEfksaWiTc+beDjBkPEnr7iVlKfu8SeyCT8Sef+KsonRgIj6pl3SiWDPSefWmeicw==}
+  github-changelog@2.1.1:
+    resolution: {integrity: sha512-MRJXYVBJi5EUtIvaMokAIMAOmDwx8EtO2xK2yhK/jSHQBRGVwuhVGYhSCWPSnku8MTtL4mfk2qFNqUhx2ZC98A==}
     engines: {node: 18.* || 20.* || >= 22}
     hasBin: true
 
@@ -3040,7 +3040,7 @@ snapshots:
   '@npmcli/fs@1.1.1':
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.5.4
+      semver: 7.7.2
 
   '@npmcli/git@6.0.1':
     dependencies:
@@ -4360,7 +4360,7 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  github-changelog@2.0.0:
+  github-changelog@2.1.1:
     dependencies:
       '@manypkg/get-packages': 2.2.0
       chalk: 4.1.2

--- a/src/gather-changes.ts
+++ b/src/gather-changes.ts
@@ -9,6 +9,7 @@ export async function gatherChanges() {
 
   const result = await execa('node', [
     resolve(dirname(githubChangelogPath), 'bin', 'cli.js'),
+    '--ignore-versions',
     '--next-version',
     'Release',
   ]);


### PR DESCRIPTION
If you're doing a multi-branch release system with pre-releases and merging between branches things can start to get a bit messy 🙈 

We need to consider every release as a brand new release in terms of the changelog so we are making use of the new feature from github-changelog `--ignore-releases` https://github.com/embroider-build/github-changelog/pull/53