### PR TITLE
Drop support for Node < 22 and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,22 +22,29 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
 
-  test:
-    name: "Test"
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+  tests:
+    name: 'Tests on Node.js ${{ matrix.node-version }} - ${{ matrix.os }}'
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['22', '24', '26']
+        os:
+          - 'ubuntu-latest'
+          - 'windows-latest'
 
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: ${{ matrix.node-version }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm test --coverage.enabled true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
         node-version: ["22", "24", "26"]
         os:
           - "ubuntu-latest"
-          - "windows-latest"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,16 +28,16 @@ jobs:
       - run: pnpm lint
 
   tests:
-    name: 'Tests on Node.js ${{ matrix.node-version }} - ${{ matrix.os }}'
+    name: "Tests on Node.js ${{ matrix.node-version }} - ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['22', '24', '26']
+        node-version: ["22", "24", "26"]
         os:
-          - 'ubuntu-latest'
-          - 'windows-latest'
+          - "ubuntu-latest"
+          - "windows-latest"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm test --coverage.enabled true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
       - run: npm install -g npm@latest # ensure that the globally installed npm is new enough to support OIDC

--- a/package.json
+++ b/package.json
@@ -68,5 +68,8 @@
     "vitepress-plugin-mermaid": "^2.0.17",
     "vitest": "^3.0.6"
   },
-  "packageManager": "pnpm@10.4.1"
+  "packageManager": "pnpm@10.4.1",
+  "engines": {
+    "node": "22.* || 24.* || >= 26"
+  }
 }

--- a/src/interdep.ts
+++ b/src/interdep.ts
@@ -24,7 +24,7 @@ export function getPackages(rootDir: string): Map<string, PkgEntry> {
 
     packages.set(pkg.name, {
       version: pkg.version,
-      pkgJSONPath: `./${relative('.', packagePath)}`,
+      pkgJSONPath: `./${relative('.', packagePath).replace(/\\/g, '/')}`,
       isDependencyOf: new Map(),
       isPeerDependencyOf: new Map(),
       pkg,

--- a/src/interdep.ts
+++ b/src/interdep.ts
@@ -24,7 +24,7 @@ export function getPackages(rootDir: string): Map<string, PkgEntry> {
 
     packages.set(pkg.name, {
       version: pkg.version,
-      pkgJSONPath: `./${relative('.', packagePath).replace(/\\/g, '/')}`,
+      pkgJSONPath: `./${relative('.', packagePath)}`,
       isDependencyOf: new Map(),
       isPeerDependencyOf: new Map(),
       pkg,


### PR DESCRIPTION
This PR drops node < 22 & adds test matrix for node 22, 24 & 26.
After merging this one, we can update github-changelog to v3.x (https://github.com/release-plan/github-changelog/releases/tag/v3.0.0) to resolve the security issues from `tar`