### PR TITLE
Add an option to disable changelog generation

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -69,6 +69,26 @@ When you use `release-plan` to publish to npm it will by default publish your pa
 
 :::
 
+## `skipChangelogUpdate`
+
+By default `release-plan prepare` prepends the release notes to `CHANGELOG.md`. Setting `skipChangelogUpdate` to `true` leaves that file alone — versions are still bumped and the notes are still used as the body of the GitHub release. This is useful if you generate your changelog by some other means, or don't keep one in the repo at all.
+
+Unlike the other settings, this one is only read from the `release-plan` section of the **root** `package.json`, because there is a single changelog per release.
+
+::: code-group
+
+```json [package.json]
+{
+  "name": "example",
+  "version": "1.0.0",
+  "release-plan": {
+    "skipChangelogUpdate": true
+  }
+}
+```
+
+:::
+
 ## `ignore`
 
 In a monorepo you may want `release-plan` to only manage a subset of your workspace packages. Setting `ignore` to `true` tells `release-plan` to leave that package alone entirely. This is useful when a package is released by "some other means" but can't be marked `"private": true` (because it is actually published).

--- a/src/prepare-changelog.test.ts
+++ b/src/prepare-changelog.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+
+import { prepare } from './prepare.js';
+
+import { Project } from 'fixturify-project';
+import { readFileSync, writeFileSync } from 'fs';
+
+const CHANGELOG = `# Changelog
+
+## v1.2.3
+
+- the previous release
+`;
+
+const newChangelogContent = `## v1.3.0
+
+#### :rocket: Enhancement
+* \`test-package\`
+  * [#1](https://github.com/example/example/pull/1) did a thing
+`;
+
+describe('prepare', function () {
+  let project;
+  let realCwd;
+
+  beforeEach(async () => {
+    project = new Project('test-package', '1.2.3', {
+      files: {
+        'CHANGELOG.md': CHANGELOG,
+      },
+    });
+
+    await project.write();
+    realCwd = process.cwd();
+    process.chdir(project.baseDir);
+  });
+
+  afterEach(() => {
+    process.chdir(realCwd);
+  });
+
+  function setConfig(config: Record<string, unknown>) {
+    const pkg = JSON.parse(readFileSync('./package.json', 'utf8'));
+    pkg['release-plan'] = config;
+    writeFileSync('./package.json', JSON.stringify(pkg));
+  }
+
+  it('updates the changelog by default', async () => {
+    await prepare(newChangelogContent);
+
+    expect(readFileSync('./CHANGELOG.md', 'utf8')).toContain('## v1.3.0');
+  });
+
+  it('leaves the changelog alone when skipChangelogUpdate is set', async () => {
+    setConfig({ skipChangelogUpdate: true });
+
+    await prepare(newChangelogContent);
+
+    expect(readFileSync('./CHANGELOG.md', 'utf8')).toEqual(CHANGELOG);
+  });
+
+  it('still bumps versions and saves a description when skipChangelogUpdate is set', async () => {
+    setConfig({ skipChangelogUpdate: true });
+
+    await prepare(newChangelogContent);
+
+    expect(JSON.parse(readFileSync('./package.json', 'utf8')).version).toEqual(
+      '1.3.0',
+    );
+    expect(
+      JSON.parse(readFileSync('./.release-plan.json', 'utf8')).description,
+    ).toContain('did a thing');
+  });
+});

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -54,6 +54,12 @@ function versionSummary(solution: Solution): string {
   return result.join('\n');
 }
 
+function skipChangelogUpdate(): boolean {
+  return Boolean(
+    readJSONSync('./package.json')['release-plan']?.skipChangelogUpdate,
+  );
+}
+
 function updateVersions(solution: Solution) {
   for (const entry of solution.values()) {
     if (entry.impact) {
@@ -71,7 +77,9 @@ export async function prepare(
   const changes = parseChangeLogOrExit(newChangelogContent);
   const solution = planVersionBumps(changes, singlePackage);
   updateVersions(solution);
-  const description = updateChangelog(newChangelogContent, solution);
+  const description = skipChangelogUpdate()
+    ? newChangelogContent
+    : updateChangelog(newChangelogContent, solution);
   saveSolution(solution, description);
   return solution;
 }


### PR DESCRIPTION
Why?:
- for repos with mulit-release-tool implementations (such as ember-source), there is a main changelog that is for the main package -- we don't want release-plan touching that one.

Now, it _would_ be better if release-plan had an option to have per-package changelogs for this use case -- especially since in the ember-source monorepo, there are a couple not-so-related packages (which are in the same repo for convenience more than "same project" (sorta, it's kinda weird))