### PR TITLE
Add option to have a changelog per package

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -69,6 +69,50 @@ When you use `release-plan` to publish to npm it will by default publish your pa
 
 :::
 
+## `changelogPerPackage`
+
+By default `release-plan` maintains a single `CHANGELOG.md` at the root of the repo, listing every released package together. Set `changelogPerPackage` to `true` and it instead writes a `CHANGELOG.md` next to each released package's `package.json`, containing only that package's changes. The root `CHANGELOG.md` is left untouched from then on.
+
+Unlike the other settings on this page, this one describes the whole repo, so it is only read from the workspace root `package.json`.
+
+::: code-group
+
+```json [package.json]
+{
+  "name": "my-monorepo",
+  "private": true,
+  "release-plan": {
+    "changelogPerPackage": true
+  }
+}
+```
+
+:::
+
+A package's changelog gets one section per changelog heading, carrying just the pull requests attributed to it:
+
+```md
+## v1.3.0 (2026-08-14)
+
+#### :rocket: Enhancement
+
+- [#1](https://github.com/my-org/my-repo/pull/1) Grew a nose ([@someone](https://github.com/someone))
+```
+
+Packages released only because a workspace dependency was released have no pull requests of their own, so they get a section explaining the bump instead:
+
+```md
+## v0.1.1 (2026-08-14)
+
+#### :arrow_up: Dependency Updates
+
+- Has dependency `workspace:^` on face
+```
+
+Changes that GitHub could not attribute to any package (the `Other` bucket) bump no package, so they appear in no package's changelog. The GitHub release body still describes the release as a whole, exactly as it does without this setting.
+
+Packages that don't have a `CHANGELOG.md` yet get one created.
+
 ## `ignore`
 
 In a monorepo you may want `release-plan` to only manage a subset of your workspace packages. Setting `ignore` to `true` tells `release-plan` to leave that package alone entirely. This is useful when a package is released by "some other means" but can't be marked `"private": true` (because it is actually published).

--- a/src/change-parser.test.ts
+++ b/src/change-parser.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+
+import { parseChangeLog } from './change-parser.js';
+
+describe('change-parser', function () {
+  it('captures the entries belonging to each package list', function () {
+    const parsed = parseChangeLog(`## Release (2026-08-14)
+
+#### :rocket: Enhancement
+* \`pkg-a\`, \`pkg-b\`
+  * [#1](https://example.com/1) Shared feature ([@someone](https://example.com/someone))
+  * [#2](https://example.com/2) Another shared feature ([@someone](https://example.com/someone))
+* \`pkg-c\`
+  * [#3](https://example.com/3) Solo feature ([@someone](https://example.com/someone))
+
+#### :bug: Bug Fix
+* \`pkg-a\`
+  * [#4](https://example.com/4) A fix ([@someone](https://example.com/someone))
+
+#### Committers: 1
+- Someone ([@someone](https://example.com/someone))
+`);
+
+    expect(parsed).to.deep.equal({
+      sections: [
+        {
+          packages: ['pkg-a', 'pkg-b', 'pkg-c'],
+          groups: [
+            {
+              packages: ['pkg-a', 'pkg-b'],
+              entries: [
+                '[#1](https://example.com/1) Shared feature ([@someone](https://example.com/someone))',
+                '[#2](https://example.com/2) Another shared feature ([@someone](https://example.com/someone))',
+              ],
+            },
+            {
+              packages: ['pkg-c'],
+              entries: [
+                '[#3](https://example.com/3) Solo feature ([@someone](https://example.com/someone))',
+              ],
+            },
+          ],
+          impact: 'minor',
+          heading: ':rocket: Enhancement',
+        },
+        {
+          packages: ['pkg-a'],
+          groups: [
+            {
+              packages: ['pkg-a'],
+              entries: [
+                '[#4](https://example.com/4) A fix ([@someone](https://example.com/someone))',
+              ],
+            },
+          ],
+          impact: 'patch',
+          heading: ':bug: Bug Fix',
+        },
+      ],
+    });
+  });
+
+  it('collects unattributed entries into a group with no packages', function () {
+    const parsed = parseChangeLog(`## Release (2026-08-14)
+
+#### :bug: Bug Fix
+* [#1](https://example.com/1) A fix ([@someone](https://example.com/someone))
+* [#2](https://example.com/2) Another fix ([@someone](https://example.com/someone))
+`);
+
+    expect(parsed.sections).to.deep.equal([
+      {
+        packages: [],
+        groups: [
+          {
+            packages: [],
+            entries: [
+              '[#1](https://example.com/1) A fix ([@someone](https://example.com/someone))',
+              '[#2](https://example.com/2) Another fix ([@someone](https://example.com/someone))',
+            ],
+          },
+        ],
+        impact: 'patch',
+        heading: ':bug: Bug Fix',
+      },
+    ]);
+  });
+
+  it('treats the Other bucket as unattributed', function () {
+    const parsed = parseChangeLog(`## Release (2026-08-14)
+
+#### :house: Internal
+* \`pkg-a\`
+  * [#1](https://example.com/1) Real change ([@someone](https://example.com/someone))
+* Other
+  * [#2](https://example.com/2) Repo chore ([@someone](https://example.com/someone))
+`);
+
+    expect(parsed.sections[0]).to.deep.equal({
+      packages: ['pkg-a'],
+      groups: [
+        {
+          packages: ['pkg-a'],
+          entries: [
+            '[#1](https://example.com/1) Real change ([@someone](https://example.com/someone))',
+          ],
+        },
+        {
+          packages: [],
+          entries: [
+            '[#2](https://example.com/2) Repo chore ([@someone](https://example.com/someone))',
+          ],
+        },
+      ],
+      impact: 'patch',
+      heading: ':house: Internal',
+    });
+  });
+});

--- a/src/change-parser.ts
+++ b/src/change-parser.ts
@@ -1,7 +1,14 @@
 export type Impact = 'major' | 'minor' | 'patch';
 export type UnlabeledSection = { unlabeled: true; summaryText: string };
+
+// entries are the change descriptions with their leading bullet stripped.
+// packages is empty for the "Other" group and for repos whose changelog has no
+// package attribution at all.
+export type ChangeGroup = { packages: string[]; entries: string[] };
+
 export type LabeledSection = {
   packages: string[];
+  groups: ChangeGroup[];
   impact: Impact;
   heading: string;
 };
@@ -76,26 +83,57 @@ function parseSection(lines: string[]): Section | undefined {
   }
 
   const packages = new Set<string>();
+  const groups: ChangeGroup[] = [];
+  let unattributed: ChangeGroup | undefined;
+
   while (stillWithinSection(lines)) {
-    const packageList = parsePackageList(lines);
+    const line = lines.shift()!;
+    if (!line.trim()) {
+      continue;
+    }
+
+    const packageList = parsePackageList(line);
     if (packageList) {
       for (const pkg of packageList) {
         packages.add(pkg);
       }
+      groups.push({ packages: packageList, entries: consumeEntries(lines) });
+      continue;
+    }
+
+    if (!unattributed) {
+      unattributed = { packages: [], entries: [] };
+      groups.push(unattributed);
+    }
+    if (line === '* Other') {
+      unattributed.entries.push(...consumeEntries(lines));
+    } else {
+      unattributed.entries.push(stripBullet(line));
     }
   }
+
   return {
     packages: [...packages],
+    groups,
     impact: sectionConfig.impact,
     heading,
   };
 }
 
-function parsePackageList(lines: string[]): string[] | undefined {
-  const line = lines.shift();
-  if (!line) {
-    return;
+function stripBullet(line: string): string {
+  return line.replace(/^\s*\*\s+/, '');
+}
+
+// the change descriptions belonging to a package list are indented beneath it
+function consumeEntries(lines: string[]): string[] {
+  const entries: string[] = [];
+  while (stillWithinSection(lines) && /^\s+\*\s/.test(lines[0])) {
+    entries.push(stripBullet(lines.shift()!));
   }
+  return entries;
+}
+
+function parsePackageList(line: string): string[] | undefined {
   if (line === '* Other') {
     return;
   }

--- a/src/changelog-file.ts
+++ b/src/changelog-file.ts
@@ -1,0 +1,35 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+
+const changelogPreamblePattern = /#.*Changelog.*$/i;
+
+/**
+ * Inserts a release entry directly beneath the changelog's preamble heading.
+ *
+ * @param file path to the changelog
+ * @param entry the release entry, newline terminated
+ * @param createIfMissing write a fresh changelog when none exists yet
+ */
+export function prependToChangelog(
+  file: string,
+  entry: string,
+  createIfMissing = false,
+): void {
+  if (createIfMissing && !existsSync(file)) {
+    writeFileSync(file, `# Changelog\n\n${entry}`);
+    return;
+  }
+
+  const oldContent = readFileSync(file, 'utf8').split('\n');
+
+  if (!changelogPreamblePattern.test(oldContent[0])) {
+    process.stderr.write(
+      `Cannot parse existing changelog ${file}. Expected it to match:\n${changelogPreamblePattern}\n`,
+    );
+    process.exit(-1);
+  }
+
+  writeFileSync(
+    file,
+    oldContent[0] + '\n\n' + entry + oldContent.slice(1).join('\n'),
+  );
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,15 @@
+import { existsSync } from 'node:fs';
+
+// eslint-disable-next-line n/no-missing-import
+import { readJSONSync } from './util.js';
+
+// unlike the per-package settings read in plan.ts, this one describes the whole
+// repo, so it is only honored at the workspace root
+export function changelogPerPackage(): boolean {
+  if (!existsSync('./package.json')) {
+    return false;
+  }
+  return (
+    readJSONSync('./package.json')['release-plan']?.changelogPerPackage === true
+  );
+}

--- a/src/per-package-changelog.test.ts
+++ b/src/per-package-changelog.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+
+import { prepare } from './prepare.js';
+
+import { Project } from 'fixturify-project';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+const changelog = `## Release (2026-08-14)
+
+#### :rocket: Enhancement
+* \`face\`
+  * [#1](https://example.com/1) Grew a nose ([@someone](https://example.com/someone))
+
+#### :bug: Bug Fix
+* \`face\`
+  * [#2](https://example.com/2) Unswapped the eyes ([@someone](https://example.com/someone))
+* Other
+  * [#3](https://example.com/3) Fixed CI ([@someone](https://example.com/someone))
+
+#### Committers: 1
+- Someone ([@someone](https://example.com/someone))
+`;
+
+describe('per-package changelogs', function () {
+  let project: Project;
+  let realCwd: string;
+
+  async function setup(rootConfig: Record<string, unknown>) {
+    project = new Project('test-package', '1.2.3', {
+      files: {
+        'pnpm-workspace.yaml': `packages:
+  - packages/*
+`,
+        packages: {
+          face: {
+            'package.json': JSON.stringify({
+              name: 'face',
+              version: '0.1.0',
+            }),
+          },
+          hand: {
+            'package.json': JSON.stringify({
+              name: 'hand',
+              version: '0.1.0',
+              dependencies: { face: 'workspace:^' },
+            }),
+          },
+        },
+      },
+    });
+
+    project.pkg.private = true;
+    project.pkg['release-plan'] = rootConfig;
+
+    await project.write();
+    realCwd = process.cwd();
+    process.chdir(project.baseDir);
+  }
+
+  afterEach(() => {
+    process.chdir(realCwd);
+  });
+
+  describe('enabled', function () {
+    beforeEach(() => setup({ changelogPerPackage: true }));
+
+    it('writes a changelog into each released package and leaves the root alone', async function () {
+      await prepare(changelog);
+
+      expect(existsSync('./CHANGELOG.md')).to.eq(false);
+
+      expect(readFileSync('packages/face/CHANGELOG.md', 'utf8')).to
+        .eq(`# Changelog
+
+## v0.2.0 (2026-08-14)
+
+#### :rocket: Enhancement
+* [#1](https://example.com/1) Grew a nose ([@someone](https://example.com/someone))
+
+#### :bug: Bug Fix
+* [#2](https://example.com/2) Unswapped the eyes ([@someone](https://example.com/someone))
+`);
+    });
+
+    it('explains dependency-only bumps', async function () {
+      await prepare(changelog);
+
+      expect(readFileSync('packages/hand/CHANGELOG.md', 'utf8')).to
+        .eq(`# Changelog
+
+## v0.1.1 (2026-08-14)
+
+#### :arrow_up: Dependency Updates
+* Has dependency \`workspace:^\` on face
+`);
+    });
+
+    it('prepends to an existing package changelog', async function () {
+      writeFileSync(
+        join('packages', 'face', 'CHANGELOG.md'),
+        `# Changelog
+
+## v0.1.0 (2026-01-01)
+
+#### :rocket: Enhancement
+* [#0](https://example.com/0) The first face ([@someone](https://example.com/someone))
+`,
+      );
+
+      await prepare(changelog);
+
+      expect(readFileSync('packages/face/CHANGELOG.md', 'utf8')).to
+        .eq(`# Changelog
+
+## v0.2.0 (2026-08-14)
+
+#### :rocket: Enhancement
+* [#1](https://example.com/1) Grew a nose ([@someone](https://example.com/someone))
+
+#### :bug: Bug Fix
+* [#2](https://example.com/2) Unswapped the eyes ([@someone](https://example.com/someone))
+
+## v0.1.0 (2026-01-01)
+
+#### :rocket: Enhancement
+* [#0](https://example.com/0) The first face ([@someone](https://example.com/someone))
+`);
+    });
+
+    it('still describes the whole release in the release plan', async function () {
+      await prepare(changelog);
+
+      const { description } = JSON.parse(
+        readFileSync('.release-plan.json', 'utf8'),
+      );
+
+      expect(description).to.contain('* face 0.2.0 (minor)');
+      expect(description).to.contain('* hand 0.1.1 (patch)');
+    });
+  });
+
+  describe('disabled', function () {
+    beforeEach(() => setup({}));
+
+    it('keeps writing the single root changelog', async function () {
+      writeFileSync('./CHANGELOG.md', '# Changelog\n');
+
+      await prepare(changelog);
+
+      expect(existsSync('packages/face/CHANGELOG.md')).to.eq(false);
+      expect(readFileSync('./CHANGELOG.md', 'utf8')).to.contain(
+        '* face 0.2.0 (minor)',
+      );
+    });
+  });
+});

--- a/src/per-package-changelog.ts
+++ b/src/per-package-changelog.ts
@@ -1,0 +1,94 @@
+import { dirname, join } from 'node:path';
+import type { ParsedChangelog } from './change-parser.js';
+import type { Solution } from './plan.js';
+import { prependToChangelog } from './changelog-file.js';
+
+const dependencyUpdatesHeading = ':arrow_up: Dependency Updates';
+
+type RenderedSection = { heading: string; entries: string[] };
+
+export function updatePackageChangelogs(
+  newChangelogContent: string,
+  changes: ParsedChangelog,
+  solution: Solution,
+  singlePackage?: string,
+): void {
+  const date = releaseDate(newChangelogContent);
+
+  for (const [pkgName, entry] of solution) {
+    if (!entry.impact) {
+      continue;
+    }
+
+    const sections = sectionsFor(changes, pkgName, singlePackage);
+
+    const dependencyUpdates = entry.constraints
+      .filter((constraint) => constraint.kind === 'dependency')
+      .map((constraint) => constraint.reason);
+
+    if (dependencyUpdates.length > 0) {
+      sections.push({
+        heading: dependencyUpdatesHeading,
+        entries: dependencyUpdates,
+      });
+    }
+
+    prependToChangelog(
+      join(dirname(entry.pkgJSONPath), 'CHANGELOG.md'),
+      render(entry.newVersion, date, sections),
+      true,
+    );
+  }
+}
+
+function render(
+  newVersion: string,
+  date: string,
+  sections: RenderedSection[],
+): string {
+  const lines = [`## v${newVersion} (${date})`];
+
+  for (const section of sections) {
+    lines.push('', `#### ${section.heading}`);
+    lines.push(...section.entries.map((entry) => `* ${entry}`));
+  }
+
+  return lines.join('\n') + '\n';
+}
+
+function sectionsFor(
+  changes: ParsedChangelog,
+  pkgName: string,
+  singlePackage: string | undefined,
+): RenderedSection[] {
+  const sections: RenderedSection[] = [];
+
+  for (const section of changes.sections) {
+    if ('unlabeled' in section) {
+      continue;
+    }
+
+    const entries = section.groups
+      .filter((group) =>
+        // outside a monorepo nothing is attributed, so every change is this
+        // package's change. Within one, unattributed changes bump nothing and
+        // so belong in no package's changelog.
+        singlePackage ? true : group.packages.includes(pkgName),
+      )
+      .flatMap((group) => group.entries);
+
+    if (entries.length > 0) {
+      sections.push({ heading: section.heading, entries });
+    }
+  }
+
+  return sections;
+}
+
+function releaseDate(newChangelogContent: string): string {
+  const heading = newChangelogContent.trim().split('\n')[0];
+  const parenthesized = /\(([^)]*)\)\s*$/.exec(heading);
+  return parenthesized
+    ? parenthesized[1]
+    : new Date().toISOString().slice(0, 10);
+}

--- a/src/plan.test.ts
+++ b/src/plan.test.ts
@@ -45,6 +45,7 @@ describe('plan', function () {
       sections: [
         {
           packages: ['test-package'],
+          groups: [],
           impact: 'minor',
           heading: 'enhancement',
         },
@@ -67,6 +68,7 @@ describe('plan', function () {
               {
                 impact: 'minor',
                 reason: 'Appears in changelog section enhancement',
+                kind: 'changelog',
               },
             ],
             impact: 'minor',
@@ -85,6 +87,7 @@ describe('plan', function () {
       sections: [
         {
           packages: ['face'],
+          groups: [],
           impact: 'minor',
           heading: 'enhancement',
         },
@@ -100,6 +103,7 @@ describe('plan', function () {
               {
                 impact: 'minor',
                 reason: 'Appears in changelog section enhancement',
+                kind: 'changelog',
               },
             ],
             impact: 'minor',
@@ -116,6 +120,7 @@ describe('plan', function () {
               {
                 impact: 'patch',
                 reason: 'Has dependency `workspace:*` on face',
+                kind: 'dependency',
               },
             ],
             impact: 'patch',
@@ -134,6 +139,7 @@ describe('plan', function () {
       sections: [
         {
           packages: ['face-not-exist'],
+          groups: [],
           impact: 'major',
           heading: 'enhancement',
         },
@@ -179,6 +185,7 @@ describe('plan', function () {
       sections: [
         {
           packages: ['test-package'],
+          groups: [],
           impact: 'minor',
           heading: 'enhancement',
         },
@@ -201,6 +208,7 @@ describe('plan', function () {
               {
                 impact: 'minor',
                 reason: 'Appears in changelog section enhancement',
+                kind: 'changelog',
               },
             ],
             impact: 'minor',
@@ -231,6 +239,7 @@ describe('plan', function () {
       sections: [
         {
           packages: ['face'],
+          groups: [],
           impact: 'minor',
           heading: 'enhancement',
         },
@@ -248,6 +257,7 @@ describe('plan', function () {
               {
                 impact: 'minor',
                 reason: 'Appears in changelog section enhancement',
+                kind: 'changelog',
               },
             ],
             newVersion: '0.2.0',
@@ -262,6 +272,7 @@ describe('plan', function () {
               {
                 impact: 'patch',
                 reason: 'Has dependency `workspace:*` on face',
+                kind: 'dependency',
               },
             ],
             impact: 'patch',
@@ -295,6 +306,7 @@ describe('plan', function () {
       sections: [
         {
           packages: ['test-package'],
+          groups: [],
           impact: 'major',
           heading: 'breaking',
         },
@@ -317,6 +329,7 @@ describe('plan', function () {
               {
                 impact: 'major',
                 reason: 'Appears in changelog section breaking',
+                kind: 'changelog',
               },
             ],
             impact: 'major',
@@ -362,6 +375,7 @@ describe('plan', function () {
         sections: [
           {
             packages: ['test-package'],
+            groups: [],
             impact: 'minor',
             heading: 'enhancement',
           },
@@ -384,6 +398,7 @@ describe('plan', function () {
                 {
                   impact: 'minor',
                   reason: 'Appears in changelog section enhancement',
+                  kind: 'changelog',
                 },
               ],
               impact: 'minor',

--- a/src/plan.ts
+++ b/src/plan.ts
@@ -12,6 +12,15 @@ const { inc, satisfies } = semver;
 // eslint-disable-next-line n/no-missing-import
 import { readJSONSync, writeJSONSync } from './util.js';
 
+// 'dependency' constraints come from bumping a workspace dependency rather than
+// from a change to the package itself
+export type ConstraintKind = 'changelog' | 'dependency';
+export type Constraint = {
+  impact: Impact;
+  reason: string;
+  kind: ConstraintKind;
+};
+
 export type Solution = Map<
   string,
   | { impact: undefined; oldVersion: string }
@@ -20,27 +29,32 @@ export type Solution = Map<
       oldVersion: string;
       newVersion: string;
       tagName: string;
-      constraints: { impact: Impact; reason: string }[];
+      constraints: Constraint[];
       pkgJSONPath: string;
     }
 >;
 
 class Plan {
-  #constraints: Map<string, { impact: Impact; reason: string }[]>;
+  #constraints: Map<string, Constraint[]>;
   #pkgs: ReturnType<typeof publishedInterPackageDeps>;
 
   constructor() {
     this.#pkgs = publishedInterPackageDeps();
 
     // initialize constraints for every published package
-    const constraints = new Map<string, { impact: Impact; reason: string }[]>();
+    const constraints = new Map<string, Constraint[]>();
     for (const pkg of this.#pkgs.keys()) {
       constraints.set(pkg, []);
     }
     this.#constraints = constraints;
   }
 
-  addConstraint(packageName: string, impact: Impact, reason: string): void {
+  addConstraint(
+    packageName: string,
+    impact: Impact,
+    reason: string,
+    kind: ConstraintKind,
+  ): void {
     const pkgConstraints = this.#constraints.get(packageName);
     if (!pkgConstraints) {
       console.warn(chalk.yellow(`Warning: unknown package "${packageName}"`));
@@ -51,7 +65,7 @@ class Plan {
         (existing) => existing.impact === impact && existing.reason === reason,
       )
     ) {
-      pkgConstraints.push({ impact, reason });
+      pkgConstraints.push({ impact, reason, kind });
       this.#propagate(packageName, impact);
     }
   }
@@ -161,6 +175,7 @@ class Plan {
             consumerName,
             'patch',
             `Has dependency ${'`'}${workspaceRange}${'`'} on ${packageName}`,
+            'dependency',
           );
           break;
         case 'peerDependencies':
@@ -168,6 +183,7 @@ class Plan {
             consumerName,
             'major',
             `Has peer dependency ${'`'}${workspaceRange}${'`'} on ${packageName}`,
+            'dependency',
           );
           break;
         default:
@@ -267,6 +283,7 @@ export function planVersionBumps(
         singlePackage,
         section.impact,
         `Appears in changelog section ${section.heading}`,
+        'changelog',
       );
     } else {
       for (const pkg of section.packages) {
@@ -274,6 +291,7 @@ export function planVersionBumps(
           pkg,
           section.impact,
           `Appears in changelog section ${section.heading}`,
+          'changelog',
         );
       }
     }

--- a/src/prepare.test.ts
+++ b/src/prepare.test.ts
@@ -4,6 +4,7 @@ import { updateChangelog } from './prepare.js';
 
 const mocks = vi.hoisted(() => {
   return {
+    existsSync: vi.fn().mockImplementation(() => true),
     readFileSync: vi.fn().mockImplementation(() => ''),
     writeFileSync: vi.fn().mockImplementation(() => ''),
   };

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -1,47 +1,39 @@
 import { parseChangeLogOrExit } from './change-parser.js';
-import { readFileSync, writeFileSync } from 'node:fs';
 import type { Solution } from './plan.js';
 import { planVersionBumps, saveSolution } from './plan.js';
+import { prependToChangelog } from './changelog-file.js';
+import { changelogPerPackage } from './config.js';
+import { updatePackageChangelogs } from './per-package-changelog.js';
 // eslint-disable-next-line n/no-missing-import
 import { readJSONSync, writeJSONSync } from './util.js';
 
-const changelogPreamblePattern = /#.*Changelog.*$/i;
-
-export function updateChangelog(
+// also used as the body of the GitHub release, so it is built even when no
+// aggregate changelog gets written
+export function releaseEntry(
   newChangelogContent: string,
   solution: Solution,
 ): string {
-  const targetChangelogFile = './CHANGELOG.md';
-  const oldChangelogContent = readFileSync(targetChangelogFile, 'utf8').split(
-    '\n',
-  );
-
-  if (!changelogPreamblePattern.test(oldChangelogContent[0])) {
-    process.stderr.write(
-      `Cannot parse existing changelog. Expected it to match:\n${changelogPreamblePattern}\n`,
-    );
-    process.exit(-1);
-  }
-
   const [firstNewLine, ...restNewLines] = newChangelogContent
     .trim()
     .split('\n');
 
-  const newOutput =
+  return (
     firstNewLine +
     '\n\n' +
     versionSummary(solution) +
     '\n' +
     restNewLines.join('\n') +
-    '\n';
-  writeFileSync(
-    targetChangelogFile,
-    oldChangelogContent[0] +
-      '\n\n' +
-      newOutput +
-      oldChangelogContent.slice(1).join('\n'),
+    '\n'
   );
-  return newOutput;
+}
+
+export function updateChangelog(
+  newChangelogContent: string,
+  solution: Solution,
+): string {
+  const entry = releaseEntry(newChangelogContent, solution);
+  prependToChangelog('./CHANGELOG.md', entry);
+  return entry;
 }
 
 function versionSummary(solution: Solution): string {
@@ -71,7 +63,20 @@ export async function prepare(
   const changes = parseChangeLogOrExit(newChangelogContent);
   const solution = planVersionBumps(changes, singlePackage);
   updateVersions(solution);
-  const description = updateChangelog(newChangelogContent, solution);
+
+  let description: string;
+  if (changelogPerPackage()) {
+    description = releaseEntry(newChangelogContent, solution);
+    updatePackageChangelogs(
+      newChangelogContent,
+      changes,
+      solution,
+      singlePackage,
+    );
+  } else {
+    description = updateChangelog(newChangelogContent, solution);
+  }
+
   saveSolution(solution, description);
   return solution;
 }


### PR DESCRIPTION
Required for ember-source's use of release-plan (and probably any setup that uses multiple release processes)